### PR TITLE
Indica ai app/262 save data api - Cadastro de um local por formulário

### DIFF
--- a/mobile/screens/tab_navigator/indica_ai/components/LocalDetails.js
+++ b/mobile/screens/tab_navigator/indica_ai/components/LocalDetails.js
@@ -42,7 +42,9 @@ class LocalDetails extends Component {
                         bordered
                         onPress={() => {
                           //sending data to the page Register api screen through navigation
-                          this.props.navigation.navigate("RegisterAPI", {latitude:this.props.latitude, longitude:this.props.longitude, adress:this.props.adress })
+                          this.props.navigation.navigate("RegisterAPI",
+                          {latitude:this.props.latitude, longitude:this.props.longitude,
+                           adress:this.props.adress })
 
                         }}
                      >

--- a/mobile/screens/tab_navigator/indica_ai/components/LocalDetails.js
+++ b/mobile/screens/tab_navigator/indica_ai/components/LocalDetails.js
@@ -33,7 +33,7 @@ class LocalDetails extends Component {
                   </Body>
                 </CardItem>
                 <CardItem footer style={styles.cardFooter}>
-                     <Button info style={styles.button} ><Text> {"Chek-in"} </Text></Button>
+                     <Button info style={styles.button} ><Text> {"Check-in"} </Text></Button>
                      <Button
                         info
                         style={styles.button}

--- a/mobile/screens/tab_navigator/indica_ai/components/LocalDetails.js
+++ b/mobile/screens/tab_navigator/indica_ai/components/LocalDetails.js
@@ -1,4 +1,5 @@
 import { Platform } from 'react-native';
+import { createStackNavigator } from 'react-navigation';
 import React, { Component } from "react";
 import {View,Button, Text, Card, CardItem, Body } from 'native-base';
 import { Constants, Location, Permissions } from 'expo';
@@ -12,11 +13,15 @@ import Icon from 'react-native-vector-icons/Entypo';
 import Expo from "expo";
 import { withNavigation } from 'react-navigation';
 
+
 const width = Dimensions.get('window').width;
 const height = Dimensions.get('window').height / 2;
 
 class LocalDetails extends Component {
     render(){
+      console.log("___________________  COORDENADAS NOS DETALHES _______________________________________________________-");
+      console.log(this.props.latitude);
+      console.log(this.props.longitude);
         return(
             <View style = {styles.container}>
               <Card style = {styles.card}>
@@ -38,7 +43,10 @@ class LocalDetails extends Component {
                         info
                         style={styles.button}
                         bordered
-                        onPress={() => this.props.navigation.navigate("RegisterAPI")}
+                        onPress={() => {
+                          this.props.navigation.navigate("RegisterAPI")
+
+                        }}
                      >
                        <Icon
                          name='location'

--- a/mobile/screens/tab_navigator/indica_ai/components/LocalDetails.js
+++ b/mobile/screens/tab_navigator/indica_ai/components/LocalDetails.js
@@ -19,9 +19,6 @@ const height = Dimensions.get('window').height / 2;
 
 class LocalDetails extends Component {
     render(){
-      console.log("___________________  COORDENADAS NOS DETALHES _______________________________________________________-");
-      console.log(this.props.latitude);
-      console.log(this.props.longitude);
         return(
             <View style = {styles.container}>
               <Card style = {styles.card}>
@@ -44,7 +41,8 @@ class LocalDetails extends Component {
                         style={styles.button}
                         bordered
                         onPress={() => {
-                          this.props.navigation.navigate("RegisterAPI")
+                          //sending data to the page Register api screen through navigation
+                          this.props.navigation.navigate("RegisterAPI", {latitude:this.props.latitude, longitude:this.props.longitude})
 
                         }}
                      >

--- a/mobile/screens/tab_navigator/indica_ai/components/LocalDetails.js
+++ b/mobile/screens/tab_navigator/indica_ai/components/LocalDetails.js
@@ -42,7 +42,7 @@ class LocalDetails extends Component {
                         bordered
                         onPress={() => {
                           //sending data to the page Register api screen through navigation
-                          this.props.navigation.navigate("RegisterAPI", {latitude:this.props.latitude, longitude:this.props.longitude})
+                          this.props.navigation.navigate("RegisterAPI", {latitude:this.props.latitude, longitude:this.props.longitude, adress:this.props.adress })
 
                         }}
                      >

--- a/mobile/screens/tab_navigator/indica_ai/components/RegisterAPIForm.js
+++ b/mobile/screens/tab_navigator/indica_ai/components/RegisterAPIForm.js
@@ -13,7 +13,8 @@ import {
   Input,
   Label,
   Picker,
-  Textarea
+  Textarea,
+  Button
 } from 'native-base'
 import CategorySelect from './CategorySelect.js';
 
@@ -22,7 +23,11 @@ export default class RegisterAPIForm extends Component{
   constructor(props){
     super(props);
     this.state={
-      selected: undefined
+      selected: undefined,
+      jsonForm: {
+        name: null,
+        description: null
+      }
     };
   }
 
@@ -41,14 +46,22 @@ export default class RegisterAPIForm extends Component{
           style={styles.pickerForm}
           regular
         >
-        <Input placeholder='Nome' />
+        <Input placeholder='Nome'
+        />
         </Item>
         <Textarea
           rowSpan={5}
           bordered
           placeholder='Descrição'
         />
+        <View style = {styles.button }>
+        <Button block info>
+            <Text style = {{color: "white"}}>Confirmar</Text>
+          </Button>
+        </View>
       </Container>
+
+
     );
 
   }
@@ -63,10 +76,13 @@ const styles = StyleSheet.create({
     top:0,
     bottom:0,
     left:0,
-    right:0
+    right:0,
   },
   pickerForm:{
     top: 65,
     marginBottom: 74
+  },
+  button: {
+    padding: 10,
   }
 });

--- a/mobile/screens/tab_navigator/indica_ai/components/RegisterAPIForm.js
+++ b/mobile/screens/tab_navigator/indica_ai/components/RegisterAPIForm.js
@@ -20,6 +20,7 @@ import {
 } from 'native-base'
 import CategorySelect from './CategorySelect.js';
 import { withNavigation } from 'react-navigation';
+import { createStackNavigator } from 'react-navigation';
 
 export default class RegisterAPIForm extends Component{
 
@@ -39,17 +40,6 @@ export default class RegisterAPIForm extends Component{
   }
 
   render() {
-    if(this.props.requestStatus){
-      Alert.alert(
-                  'Local cadastrado com sucesso!',
-                  "",
-                  [
-                    {text: 'OK', onPress : () => console.log('ok pressed')}
-                  ],
-                  { cancelable: false }
-                )
-
-}
     return (
       <Container style={styles.container}>
         <CategorySelect/>

--- a/mobile/screens/tab_navigator/indica_ai/components/RegisterAPIForm.js
+++ b/mobile/screens/tab_navigator/indica_ai/components/RegisterAPIForm.js
@@ -19,6 +19,7 @@ import {
   Button
 } from 'native-base'
 import CategorySelect from './CategorySelect.js';
+import { withNavigation } from 'react-navigation';
 
 export default class RegisterAPIForm extends Component{
 
@@ -27,7 +28,7 @@ export default class RegisterAPIForm extends Component{
     this.state={
       selected: undefined,
       name: null,
-      description: null
+      description: null,
     };
   }
 
@@ -38,10 +39,20 @@ export default class RegisterAPIForm extends Component{
   }
 
   render() {
-    console.log("_____________________________________________________________________________________________");
-    console.log(this.state.name);
-    console.log(this.state.description);
-    console.log("_____________________________________________________________________________________________");
+    console.log("------------------  form status -------------------");
+    console.log(this.props.requestStatus);
+
+    if(this.props.requestStatus){
+      Alert.alert(
+                  'Local cadastrado com sucesso!',
+                  "",
+                  [
+                    {text: 'OK', onPress : () => console.log('ok pressed')}
+                  ],
+                  { cancelable: false }
+                )
+
+}
     return (
       <Container style={styles.container}>
         <CategorySelect/>
@@ -63,18 +74,19 @@ export default class RegisterAPIForm extends Component{
           ()=>{
           if(!(this.state.name && this.state.description)){
             Alert.alert(
-                        "Os campos 'Nome' e 'Descrição' não podem estar vazios!",
-                        '',
+                        'Atenção!',
+                        "Os campos 'Nome' ou 'Descrição' não podem estar vazios",
                         [
                           {text: 'OK', onPress: () => console.log('OK Pressed')}
                         ],
                         { cancelable: false }
                       )
           }else {
-            this.props.sendDataToTheForm(this.state.name, this.state.description)
+           this.props.sendDataToTheForm(this.state.name, this.state.description)
+               }
           }
 
-        }}>
+        }>
             <Text style = {{color: "white"}}>Confirmar</Text>
           </Button>
         </View>

--- a/mobile/screens/tab_navigator/indica_ai/components/RegisterAPIForm.js
+++ b/mobile/screens/tab_navigator/indica_ai/components/RegisterAPIForm.js
@@ -5,7 +5,8 @@ import {
   StyleSheet,
   Image,
   ScrollView,
-  TextInput
+  TextInput,
+  Alert
 } from "react-native";
 import {
   Container,
@@ -58,7 +59,22 @@ export default class RegisterAPIForm extends Component{
        placeholder="Descrição"
        onChangeText = {(description) => this.setState({description})} />
         <View style = {styles.button }>
-        <Button block info onPress = {()=>this.props.sendDataToTheForm(this.state.name, this.state.description)}>
+        <Button block info onPress = {
+          ()=>{
+          if(!(this.state.name && this.state.description)){
+            Alert.alert(
+                        "Os campos 'Nome' e 'Descrição' não podem estar vazios!",
+                        '',
+                        [
+                          {text: 'OK', onPress: () => console.log('OK Pressed')}
+                        ],
+                        { cancelable: false }
+                      )
+          }else {
+            this.props.sendDataToTheForm(this.state.name, this.state.description)
+          }
+
+        }}>
             <Text style = {{color: "white"}}>Confirmar</Text>
           </Button>
         </View>

--- a/mobile/screens/tab_navigator/indica_ai/components/RegisterAPIForm.js
+++ b/mobile/screens/tab_navigator/indica_ai/components/RegisterAPIForm.js
@@ -4,7 +4,8 @@ import {
   Text,
   StyleSheet,
   Image,
-  ScrollView
+  ScrollView,
+  TextInput
 } from "react-native";
 import {
   Container,
@@ -24,21 +25,22 @@ export default class RegisterAPIForm extends Component{
     super(props);
     this.state={
       selected: undefined,
-      jsonForm: {
-        name: null,
-        description: null
-      }
+      name: null,
+      description: null
     };
   }
 
   onValueChange(value: string) {
     this.setState({
-      selected: value
+      selected: value,
     });
   }
 
   render() {
-
+    console.log("_____________________________________________________________________________________________");
+    console.log(this.state.name);
+    console.log(this.state.description);
+    console.log("_____________________________________________________________________________________________");
     return (
       <Container style={styles.container}>
         <CategorySelect/>
@@ -47,21 +49,20 @@ export default class RegisterAPIForm extends Component{
           regular
         >
         <Input placeholder='Nome'
+        onChangeText = {(name) => this.setState({name})}
         />
         </Item>
-        <Textarea
-          rowSpan={5}
-          bordered
-          placeholder='Descrição'
-        />
+       <Textarea
+       rowSpan={5}
+       bordered
+       placeholder="Descrição"
+       onChangeText = {(description) => this.setState({description})} />
         <View style = {styles.button }>
-        <Button block info>
+        <Button block info onPress = {()=>this.props.sendDataToTheForm(this.state.name, this.state.description)}>
             <Text style = {{color: "white"}}>Confirmar</Text>
           </Button>
         </View>
       </Container>
-
-
     );
 
   }

--- a/mobile/screens/tab_navigator/indica_ai/components/RegisterAPIForm.js
+++ b/mobile/screens/tab_navigator/indica_ai/components/RegisterAPIForm.js
@@ -39,9 +39,6 @@ export default class RegisterAPIForm extends Component{
   }
 
   render() {
-    console.log("------------------  form status -------------------");
-    console.log(this.props.requestStatus);
-
     if(this.props.requestStatus){
       Alert.alert(
                   'Local cadastrado com sucesso!',

--- a/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocal.js
+++ b/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocal.js
@@ -121,10 +121,11 @@ constructor(props){
    };
    takeNewCoords = (newLatitude, newLongitude) => {
      this._getNewDataAsync(newLatitude,newLongitude);
+     this.setState({latitude: newLatitude, longitude: newLongitude});
    }
 
   render() {
-  
+
     let lat;
     let long;
 
@@ -163,6 +164,8 @@ constructor(props){
          <LocalDetails
            name = {name}
            adress = {adress}
+           latitude = {lat}
+           longitude = {long}
         />
       </View>
     )

--- a/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
+++ b/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
@@ -7,9 +7,28 @@ import RegisterAPIForm from '../components/RegisterAPIForm.js'
 
 export default class RegisterLocalAPI extends Component{
 
+ _postForm  = async (jsonForm) => {
+  try{
+    const response = await fetch('#', {method: 'POST', body: JSON.stringify(jsonForm)});
+  	if(response.ok){
+      const jsonResponse = await response.json();
+      return jsonResponse;
+    }
+    throw new Error('Request failed!');
+  }catch(error){
+    console.log(error);
+  }
+}
+
+  takeDataFromTheForm = (JsonForm) => {
+    this._postForm (JsonForm);
+  }
+
   render() {
     return (
-      <RegisterAPIForm />
+      <RegisterAPIForm
+      sendDateFromTheForm = {this.takeDataFromTheForm}
+      />
     );
   }
 

--- a/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
+++ b/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
@@ -16,14 +16,12 @@ export default class RegisterLocalAPI extends Component{
   }
 
  _postForm  = async (name,description) => {
-       console.log("DESCRIÇÃO NO POST: " + description);
-       console.log("NAME NO POST: "+name);
        const url  = "https://dev-indicaai.herokuapp.com/locals/";
        const jsonTest = JSON.stringify({
                name: name,
                category_id: 1,
-               latitude: 10.00000000,
-               longitude: 10.00000000,
+               latitude: this.props.latitude,
+               longitude: this.props.longitude,
                description: description,
                address: "rua zzzz quadra zzzz"
              });
@@ -52,8 +50,6 @@ export default class RegisterLocalAPI extends Component{
   }
 
   render() {
-    console.log("================== STATUS NO REQUEST ===================");
-    console.log(this.state.requestStatus);
     return (
       <RegisterAPIForm
       sendDataToTheForm = {this.takeDataFromTheForm}

--- a/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
+++ b/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
@@ -1,7 +1,8 @@
 import React, { Component } from "react";
 import {
   Text,
-  ScrollView
+  ScrollView,
+  Alert
 } from "react-native";
 import { withNavigation,createStackNavigator } from 'react-navigation';
 import RegisterAPIForm from '../components/RegisterAPIForm.js'
@@ -11,7 +12,7 @@ export default class RegisterLocalAPI extends Component{
   constructor(props){
     super(props);
     this.state = {
-      requestStatus: false
+      requestStatus: null
    };
   }
 
@@ -37,7 +38,9 @@ export default class RegisterLocalAPI extends Component{
           const jsonResponse = await response.json()
            console.log(jsonResponse);
            if(jsonResponse['status'] === "SUCCESS"){
-              this.setState({requestStatus: true})
+              this.setState({requestStatus: "SUCCESS"})
+            }else{
+              this.setState({requestStatus: "FAILED"})
             }
          }catch(error){
             console.error(error);
@@ -50,10 +53,29 @@ export default class RegisterLocalAPI extends Component{
   }
 
   render() {
+    if(this.state.requestStatus === "SUCCESS"){
+      Alert.alert(
+                  'Local cadastrado com sucesso!',
+                  "",
+                  [
+                    {text: 'OK', onPress : console.log("")}
+                  ],
+                  { cancelable: false }
+                )
+
+      }else if (this.state.requestStatus === "FAILED"){
+        Alert.alert(
+                    'Ooops!',
+                    "Houve um erro ao cadastrar esse local, tente novamente mais tarde",
+                    [
+                      {text: 'OK', onPress : () => console.log("OK Pressed")}
+                    ],
+                    { cancelable: false }
+                  )
+      }
     return (
       <RegisterAPIForm
       sendDataToTheForm = {this.takeDataFromTheForm}
-      requestStatus = {this.state.requestStatus}
       />
     );
   }

--- a/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
+++ b/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
@@ -7,12 +7,17 @@ import {
 import { withNavigation,createStackNavigator } from 'react-navigation';
 import RegisterAPIForm from '../components/RegisterAPIForm.js'
 
-export default class RegisterLocalAPI extends Component{
+class RegisterLocalAPI extends Component{
 
   constructor(props){
     super(props);
     this.state = {
-      requestStatus: null
+      requestStatus: null,
+      local: {
+        name: null,
+        description: null,
+        id: null
+      }
    };
   }
 
@@ -49,7 +54,13 @@ export default class RegisterLocalAPI extends Component{
 
   takeDataFromTheForm = (name, description) => {
      this._postForm (name, description);
-
+     this.setState({
+       local: {
+         name: name,
+         description: description,
+         id: null
+       }
+     })
   }
 
   render() {
@@ -58,7 +69,8 @@ export default class RegisterLocalAPI extends Component{
                   'Local cadastrado com sucesso!',
                   "",
                   [
-                    {text: 'OK', onPress : console.log("")}
+                    {text: 'OK', onPress : ()=> this.props.navigation.navigate('LocalDetails',{
+                      local: this.state.local})}
                   ],
                   { cancelable: false }
                 )
@@ -68,7 +80,7 @@ export default class RegisterLocalAPI extends Component{
                     'Ooops!',
                     "Houve um erro ao cadastrar esse local, tente novamente mais tarde",
                     [
-                      {text: 'OK', onPress : () => console.log("OK Pressed")}
+                      {text: 'OK', onPress : () => this.props.navigation.navigate("Register")}
                     ],
                     { cancelable: false }
                   )
@@ -80,3 +92,4 @@ export default class RegisterLocalAPI extends Component{
     );
   }
 }
+export default withNavigation(RegisterLocalAPI);

--- a/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
+++ b/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
@@ -8,20 +8,27 @@ import RegisterAPIForm from '../components/RegisterAPIForm.js'
 
 export default class RegisterLocalAPI extends Component{
 
+  constructor(props){
+    super(props);
+    this.state = {
+      requestStatus: false
+   };
+  }
+
  _postForm  = async (name,description) => {
        console.log("DESCRIÇÃO NO POST: " + description);
        console.log("NAME NO POST: "+name);
        const url  = "https://dev-indicaai.herokuapp.com/locals/";
        const jsonTest = JSON.stringify({
-               name: "LOCAL TEST",
+               name: name,
                category_id: 1,
                latitude: 10.00000000,
                longitude: 10.00000000,
-               description: "empty",
+               description: description,
                address: "rua zzzz quadra zzzz"
              });
-
-          fetch(url, {
+          try{
+         const response = await fetch(url, {
                    method: 'POST',
                    headers: {
                      Accept: 'application/json',
@@ -29,24 +36,28 @@ export default class RegisterLocalAPI extends Component{
                    },
                    body: jsonTest,
                  })
-         .then((response) => response.json())
-         .then((responseJson) => {
-            return responseJson.status
-          })
-         .catch((error) => {
+          const jsonResponse = await response.json()
+           console.log(jsonResponse);
+           if(jsonResponse['status'] === "SUCCESS"){
+              this.setState({requestStatus: true})
+            }
+         }catch(error){
             console.error(error);
-          });
-
+          }
       }
 
   takeDataFromTheForm = (name, description) => {
-    return this._postForm (name, description);
+     this._postForm (name, description);
+
   }
 
   render() {
+    console.log("================== STATUS NO REQUEST ===================");
+    console.log(this.state.requestStatus);
     return (
       <RegisterAPIForm
       sendDataToTheForm = {this.takeDataFromTheForm}
+      requestStatus = {this.state.requestStatus}
       />
     );
   }

--- a/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
+++ b/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
@@ -29,7 +29,7 @@ class RegisterLocalAPI extends Component{
                latitude: this.props.latitude,
                longitude: this.props.longitude,
                description: description,
-               address: "rua zzzz quadra zzzz"
+               address: this.props.adress
              });
           try{
          const response = await fetch(url, {
@@ -44,6 +44,13 @@ class RegisterLocalAPI extends Component{
            console.log(jsonResponse);
            if(jsonResponse['status'] === "SUCCESS"){
               this.setState({requestStatus: "SUCCESS"})
+              this.setState({
+                local: {
+                  name: name,
+                  description: description,
+                  id: jsonResponse["data"][0]["id"]
+                }
+              })
             }else{
               this.setState({requestStatus: "FAILED"})
             }
@@ -54,13 +61,6 @@ class RegisterLocalAPI extends Component{
 
   takeDataFromTheForm = (name, description) => {
      this._postForm (name, description);
-     this.setState({
-       local: {
-         name: name,
-         description: description,
-         id: null
-       }
-     })
   }
 
   render() {

--- a/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
+++ b/mobile/screens/tab_navigator/indica_ai/containers/RegisterLocalAPI.js
@@ -3,33 +3,51 @@ import {
   Text,
   ScrollView
 } from "react-native";
+import { withNavigation,createStackNavigator } from 'react-navigation';
 import RegisterAPIForm from '../components/RegisterAPIForm.js'
 
 export default class RegisterLocalAPI extends Component{
 
- _postForm  = async (jsonForm) => {
-  try{
-    const response = await fetch('#', {method: 'POST', body: JSON.stringify(jsonForm)});
-  	if(response.ok){
-      const jsonResponse = await response.json();
-      return jsonResponse;
-    }
-    throw new Error('Request failed!');
-  }catch(error){
-    console.log(error);
-  }
-}
+ _postForm  = async (name,description) => {
+       console.log("DESCRIÇÃO NO POST: " + description);
+       console.log("NAME NO POST: "+name);
+       const url  = "https://dev-indicaai.herokuapp.com/locals/";
+       const jsonTest = JSON.stringify({
+               name: "LOCAL TEST",
+               category_id: 1,
+               latitude: 10.00000000,
+               longitude: 10.00000000,
+               description: "empty",
+               address: "rua zzzz quadra zzzz"
+             });
 
-  takeDataFromTheForm = (JsonForm) => {
-    this._postForm (JsonForm);
+          fetch(url, {
+                   method: 'POST',
+                   headers: {
+                     Accept: 'application/json',
+                     'Content-Type': 'application/json',
+                   },
+                   body: jsonTest,
+                 })
+         .then((response) => response.json())
+         .then((responseJson) => {
+            return responseJson.status
+          })
+         .catch((error) => {
+            console.error(error);
+          });
+
+      }
+
+  takeDataFromTheForm = (name, description) => {
+    return this._postForm (name, description);
   }
 
   render() {
     return (
       <RegisterAPIForm
-      sendDateFromTheForm = {this.takeDataFromTheForm}
+      sendDataToTheForm = {this.takeDataFromTheForm}
       />
     );
   }
-
 }

--- a/mobile/screens/tab_navigator/indica_ai/screens/register_local/RegisterAPIScreen.js
+++ b/mobile/screens/tab_navigator/indica_ai/screens/register_local/RegisterAPIScreen.js
@@ -4,14 +4,25 @@ import {
   StyleSheet
 } from "react-native";
 import RegisterLocalAPI from '../../containers/RegisterLocalAPI.js';
+import { withNavigation,createStackNavigator } from 'react-navigation';
 
 
 class RegisterAPIScreen extends Component {
-
+constructor(props){
+  super(props);
+  this.state = {
+    //taking data from the page LocalDetails through navigation!!
+    latitude: this.props.navigation.state.params.latitude,
+    longitude: this.props.navigation.state.params.longitude
+  }
+}
   render() {
       return (
           <View style={styles.container}>
-              <RegisterLocalAPI />
+              <RegisterLocalAPI
+                latitude = {this.state.latitude}
+                longitude = {this.state.longitude}
+              />
           </View>
       );
   }


### PR DESCRIPTION

## Descrição 
- [x] Criar um método no container do cadastro
- [x] Esse método deve receber os dados do formulário do cadastro e enviá-los para API IndicaAi.
- [x] Ao final, uma mensagem de confirmação de cadastro deve ser enviada para o usuário, e ele deve ser redirecionado para a página de visualização do novo local.
-  [x] Se algum erro ocorrer, uma mensagem deve ser exibida para o usuário.


## Comentário 
Tudo está funcionando de acordo com o proposto pela issue, todavia notei um problema referente a navegação entre as páginas quando o usuário é levado a pagina do local recém cadastrado. No caso, a aba referente ao cadastro continua a mostrar o formulário ao invés de retornar para o local do mapa, mas como isso é um detalhe na navegação será aberta uma nova issue para esse problema. 